### PR TITLE
Add Installation Help for OSX Users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ And you're good to go!
 
 Support for building against an external PYTHIA is on the wishlist.
 
-Note that if you are using a Mac OSX system, then installation _may_ require setting an
+Note that if you are using a Mac OSX system, then installation may require setting an
 environment variable as `explained here <https://github.com/pytorch/pytorch/issues/1434>`_.
 
 Strict dependencies

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,9 @@ And you're good to go!
 
 Support for building against an external PYTHIA is on the wishlist.
 
+Note that if you are using a Mac OSX system, then installation _may_ require setting an
+environment variable as [explained here](https://github.com/pytorch/pytorch/issues/1434).
+
 Strict dependencies
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ And you're good to go!
 Support for building against an external PYTHIA is on the wishlist.
 
 Note that if you are using a Mac OSX system, then installation _may_ require setting an
-environment variable as [explained here](https://github.com/pytorch/pytorch/issues/1434).
+environment variable as `explained here <https://github.com/pytorch/pytorch/issues/1434>`_.
 
 Strict dependencies
 -------------------


### PR DESCRIPTION
It took some banging of my head on the wall to get this to install on my Mac OSX.  After some help from @eduardo-rodrigues I was able to learn about - https://github.com/pytorch/pytorch/issues/1434 - and now the `pip install -v numpythia` works just fine.

I have added this guiding information to the README for future confused people such as myself.